### PR TITLE
Upgrade to dotNetRDF 2.6.0

### DIFF
--- a/GraphBenchmarker/GraphBenchmarker.csproj
+++ b/GraphBenchmarker/GraphBenchmarker.csproj
@@ -55,11 +55,11 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="dotNetRDF, Version=2.5.0.0, Culture=neutral, PublicKeyToken=6055ffe4c97cc780, processorArchitecture=MSIL">
-      <HintPath>..\packages\dotNetRDF.2.5.0\lib\net40\dotNetRDF.dll</HintPath>
+    <Reference Include="dotNetRDF, Version=2.6.0.0, Culture=neutral, PublicKeyToken=6055ffe4c97cc780, processorArchitecture=MSIL">
+      <HintPath>..\packages\dotNetRDF.2.6.0\lib\net40\dotNetRDF.dll</HintPath>
     </Reference>
-    <Reference Include="HtmlAgilityPack, Version=1.11.23.0, Culture=neutral, PublicKeyToken=bd319b19eaf3b43a, processorArchitecture=MSIL">
-      <HintPath>..\packages\HtmlAgilityPack.1.11.23\lib\Net40\HtmlAgilityPack.dll</HintPath>
+    <Reference Include="HtmlAgilityPack, Version=1.11.24.0, Culture=neutral, PublicKeyToken=bd319b19eaf3b43a, processorArchitecture=MSIL">
+      <HintPath>..\packages\HtmlAgilityPack.1.11.24\lib\Net40\HtmlAgilityPack.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">

--- a/GraphBenchmarker/app.config
+++ b/GraphBenchmarker/app.config
@@ -9,7 +9,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="dotNetRDF" publicKeyToken="6055ffe4c97cc780" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.5.0.0" newVersion="2.5.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.6.0.0" newVersion="2.6.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/GraphBenchmarker/packages.config
+++ b/GraphBenchmarker/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="dotNetRDF" version="2.5.0" targetFramework="net40" />
-  <package id="HtmlAgilityPack" version="1.11.23" targetFramework="net40" />
+  <package id="dotNetRDF" version="2.6.0" targetFramework="net40" />
+  <package id="HtmlAgilityPack" version="1.11.24" targetFramework="net40" />
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net40" />
   <package id="VDS.Common" version="1.10.0" targetFramework="net40" />
 </packages>

--- a/Libraries/editor.wpf/packages.config
+++ b/Libraries/editor.wpf/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="AvalonEdit" version="4.4.2.9744" targetFramework="net40" />
-  <package id="dotNetRDF" version="2.5.0" targetFramework="net40" />
-  <package id="HtmlAgilityPack" version="1.11.23" targetFramework="net40" />
+  <package id="dotNetRDF" version="2.6.0" targetFramework="net40" />
+  <package id="HtmlAgilityPack" version="1.11.24" targetFramework="net40" />
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net40" />
   <package id="VDS.Common" version="1.10.0" targetFramework="net40" />
 </packages>

--- a/Libraries/editor.wpf/rdfEditor.Core.Wpf.csproj
+++ b/Libraries/editor.wpf/rdfEditor.Core.Wpf.csproj
@@ -56,11 +56,11 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="dotNetRDF, Version=2.5.0.0, Culture=neutral, PublicKeyToken=6055ffe4c97cc780, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\dotNetRDF.2.5.0\lib\net40\dotNetRDF.dll</HintPath>
+    <Reference Include="dotNetRDF, Version=2.6.0.0, Culture=neutral, PublicKeyToken=6055ffe4c97cc780, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\dotNetRDF.2.6.0\lib\net40\dotNetRDF.dll</HintPath>
     </Reference>
-    <Reference Include="HtmlAgilityPack, Version=1.11.23.0, Culture=neutral, PublicKeyToken=bd319b19eaf3b43a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\HtmlAgilityPack.1.11.23\lib\Net40\HtmlAgilityPack.dll</HintPath>
+    <Reference Include="HtmlAgilityPack, Version=1.11.24.0, Culture=neutral, PublicKeyToken=bd319b19eaf3b43a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\HtmlAgilityPack.1.11.24\lib\Net40\HtmlAgilityPack.dll</HintPath>
     </Reference>
     <Reference Include="ICSharpCode.AvalonEdit">
       <HintPath>..\..\packages\AvalonEdit.4.4.2.9744\lib\Net40\ICSharpCode.AvalonEdit.dll</HintPath>

--- a/Libraries/editor/packages.config
+++ b/Libraries/editor/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="dotNetRDF" version="2.5.0" targetFramework="net40" />
-  <package id="HtmlAgilityPack" version="1.11.23" targetFramework="net40" />
+  <package id="dotNetRDF" version="2.6.0" targetFramework="net40" />
+  <package id="HtmlAgilityPack" version="1.11.24" targetFramework="net40" />
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net40" />
   <package id="VDS.Common" version="1.10.0" targetFramework="net40" />
 </packages>

--- a/Libraries/editor/rdfEditor.Core.csproj
+++ b/Libraries/editor/rdfEditor.Core.csproj
@@ -57,11 +57,11 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="dotNetRDF, Version=2.5.0.0, Culture=neutral, PublicKeyToken=6055ffe4c97cc780, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\dotNetRDF.2.5.0\lib\net40\dotNetRDF.dll</HintPath>
+    <Reference Include="dotNetRDF, Version=2.6.0.0, Culture=neutral, PublicKeyToken=6055ffe4c97cc780, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\dotNetRDF.2.6.0\lib\net40\dotNetRDF.dll</HintPath>
     </Reference>
-    <Reference Include="HtmlAgilityPack, Version=1.11.23.0, Culture=neutral, PublicKeyToken=bd319b19eaf3b43a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\HtmlAgilityPack.1.11.23\lib\Net40\HtmlAgilityPack.dll</HintPath>
+    <Reference Include="HtmlAgilityPack, Version=1.11.24.0, Culture=neutral, PublicKeyToken=bd319b19eaf3b43a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\HtmlAgilityPack.1.11.24\lib\Net40\HtmlAgilityPack.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">

--- a/Libraries/gui.winforms/dotNetRDF.WinForms.csproj
+++ b/Libraries/gui.winforms/dotNetRDF.WinForms.csproj
@@ -56,14 +56,14 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="dotNetRDF, Version=2.5.0.0, Culture=neutral, PublicKeyToken=6055ffe4c97cc780, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\dotNetRDF.2.5.0\lib\net40\dotNetRDF.dll</HintPath>
+    <Reference Include="dotNetRDF, Version=2.6.0.0, Culture=neutral, PublicKeyToken=6055ffe4c97cc780, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\dotNetRDF.2.6.0\lib\net40\dotNetRDF.dll</HintPath>
     </Reference>
-    <Reference Include="dotNetRDF.Data.DataTables, Version=2.5.0.0, Culture=neutral, PublicKeyToken=6055ffe4c97cc780, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\dotNetRDF.Data.DataTables.2.5.0\lib\net40-client\dotNetRDF.Data.DataTables.dll</HintPath>
+    <Reference Include="dotNetRDF.Data.DataTables, Version=2.6.0.0, Culture=neutral, PublicKeyToken=6055ffe4c97cc780, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\dotNetRDF.Data.DataTables.2.6.0\lib\net40-client\dotNetRDF.Data.DataTables.dll</HintPath>
     </Reference>
-    <Reference Include="HtmlAgilityPack, Version=1.11.23.0, Culture=neutral, PublicKeyToken=bd319b19eaf3b43a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\HtmlAgilityPack.1.11.23\lib\Net40\HtmlAgilityPack.dll</HintPath>
+    <Reference Include="HtmlAgilityPack, Version=1.11.24.0, Culture=neutral, PublicKeyToken=bd319b19eaf3b43a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\HtmlAgilityPack.1.11.24\lib\Net40\HtmlAgilityPack.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">

--- a/Libraries/gui.winforms/packages.config
+++ b/Libraries/gui.winforms/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="dotNetRDF" version="2.5.0" targetFramework="net40" />
-  <package id="dotNetRDF.Data.DataTables" version="2.5.0" targetFramework="net40" />
-  <package id="HtmlAgilityPack" version="1.11.23" targetFramework="net40" />
+  <package id="dotNetRDF" version="2.6.0" targetFramework="net40" />
+  <package id="dotNetRDF.Data.DataTables" version="2.6.0" targetFramework="net40" />
+  <package id="HtmlAgilityPack" version="1.11.24" targetFramework="net40" />
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net40" />
   <package id="VDS.Common" version="1.10.0" targetFramework="net40" />
 </packages>

--- a/Libraries/storemanager.core/StoreManager.Core.csproj
+++ b/Libraries/storemanager.core/StoreManager.Core.csproj
@@ -34,14 +34,14 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="dotNetRDF, Version=2.5.0.0, Culture=neutral, PublicKeyToken=6055ffe4c97cc780, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\dotNetRDF.2.5.0\lib\net40\dotNetRDF.dll</HintPath>
+    <Reference Include="dotNetRDF, Version=2.6.0.0, Culture=neutral, PublicKeyToken=6055ffe4c97cc780, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\dotNetRDF.2.6.0\lib\net40\dotNetRDF.dll</HintPath>
     </Reference>
-    <Reference Include="dotNetRDF.Data.Virtuoso, Version=2.5.0.0, Culture=neutral, PublicKeyToken=6055ffe4c97cc780, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\dotNetRDF.Data.Virtuoso.2.5.0\lib\net40\dotNetRDF.Data.Virtuoso.dll</HintPath>
+    <Reference Include="dotNetRDF.Data.Virtuoso, Version=2.6.0.0, Culture=neutral, PublicKeyToken=6055ffe4c97cc780, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\dotNetRDF.Data.Virtuoso.2.6.0\lib\net40\dotNetRDF.Data.Virtuoso.dll</HintPath>
     </Reference>
-    <Reference Include="HtmlAgilityPack, Version=1.11.23.0, Culture=neutral, PublicKeyToken=bd319b19eaf3b43a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\HtmlAgilityPack.1.11.23\lib\Net40\HtmlAgilityPack.dll</HintPath>
+    <Reference Include="HtmlAgilityPack, Version=1.11.24.0, Culture=neutral, PublicKeyToken=bd319b19eaf3b43a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\HtmlAgilityPack.1.11.24\lib\Net40\HtmlAgilityPack.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Newtonsoft.Json.12.0.3\lib\net40\Newtonsoft.Json.dll</HintPath>

--- a/Libraries/storemanager.core/app.config
+++ b/Libraries/storemanager.core/app.config
@@ -12,7 +12,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="dotNetRDF" publicKeyToken="6055ffe4c97cc780" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.5.0.0" newVersion="2.5.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.6.0.0" newVersion="2.6.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/Libraries/storemanager.core/packages.config
+++ b/Libraries/storemanager.core/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="dotNetRDF" version="2.5.0" targetFramework="net40" />
-  <package id="dotNetRDF.Data.Virtuoso" version="2.5.0" targetFramework="net40" />
-  <package id="HtmlAgilityPack" version="1.11.23" targetFramework="net40" />
+  <package id="dotNetRDF" version="2.6.0" targetFramework="net40" />
+  <package id="dotNetRDF.Data.Virtuoso" version="2.6.0" targetFramework="net40" />
+  <package id="HtmlAgilityPack" version="1.11.24" targetFramework="net40" />
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net40" />
   <package id="OpenLink.Data.Virtuoso" version="7.20.3214.1" targetFramework="net40" />
   <package id="VDS.Common" version="1.10.0" targetFramework="net40" />

--- a/Toolkit/SparqlGUI/SparqlGUI.csproj
+++ b/Toolkit/SparqlGUI/SparqlGUI.csproj
@@ -58,14 +58,14 @@
     </CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="dotNetRDF, Version=2.5.0.0, Culture=neutral, PublicKeyToken=6055ffe4c97cc780, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\dotNetRDF.2.5.0\lib\net40\dotNetRDF.dll</HintPath>
+    <Reference Include="dotNetRDF, Version=2.6.0.0, Culture=neutral, PublicKeyToken=6055ffe4c97cc780, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\dotNetRDF.2.6.0\lib\net40\dotNetRDF.dll</HintPath>
     </Reference>
-    <Reference Include="dotNetRDF.Query.FullText, Version=2.5.0.0, Culture=neutral, PublicKeyToken=6055ffe4c97cc780, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\dotNetRDF.Query.FullText.2.5.0\lib\net40\dotNetRDF.Query.FullText.dll</HintPath>
+    <Reference Include="dotNetRDF.Query.FullText, Version=2.6.0.0, Culture=neutral, PublicKeyToken=6055ffe4c97cc780, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\dotNetRDF.Query.FullText.2.6.0\lib\net40\dotNetRDF.Query.FullText.dll</HintPath>
     </Reference>
-    <Reference Include="HtmlAgilityPack, Version=1.11.23.0, Culture=neutral, PublicKeyToken=bd319b19eaf3b43a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\HtmlAgilityPack.1.11.23\lib\Net40\HtmlAgilityPack.dll</HintPath>
+    <Reference Include="HtmlAgilityPack, Version=1.11.24.0, Culture=neutral, PublicKeyToken=bd319b19eaf3b43a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\HtmlAgilityPack.1.11.24\lib\Net40\HtmlAgilityPack.dll</HintPath>
     </Reference>
     <Reference Include="ICSharpCode.SharpZipLib, Version=0.86.0.518, Culture=neutral, PublicKeyToken=1b03e6acf1164f73, processorArchitecture=MSIL">
       <HintPath>..\..\packages\SharpZipLib.0.86.0\lib\20\ICSharpCode.SharpZipLib.dll</HintPath>

--- a/Toolkit/SparqlGUI/app.config
+++ b/Toolkit/SparqlGUI/app.config
@@ -35,7 +35,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="dotNetRDF" publicKeyToken="6055ffe4c97cc780" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-0.0.0.0" newVersion="0.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.5.0.0" newVersion="2.5.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/Toolkit/SparqlGUI/fclsSparqlGui.cs
+++ b/Toolkit/SparqlGUI/fclsSparqlGui.cs
@@ -787,8 +787,9 @@ namespace VDS.RDF.Utilities.Sparql
             {
                 //Create and ensure index ready for use
                 this._ftIndex = new RAMDirectory();
-                IndexWriter writer = new IndexWriter(this._ftIndex, new StandardAnalyzer(Lucene.Net.Util.Version.LUCENE_30), IndexWriter.MaxFieldLength.UNLIMITED);
-                writer.Close();
+                
+                var writer = new IndexWriter(this._ftIndex, new StandardAnalyzer(Lucene.Net.Util.Version.LUCENE_30), IndexWriter.MaxFieldLength.UNLIMITED);
+                writer.Dispose();
 
                 //Create Indexer and wrap dataset
                 this._ftIndexer = new LuceneObjectsIndexer(this._ftIndex, new StandardAnalyzer(Lucene.Net.Util.Version.LUCENE_30), new DefaultIndexSchema());

--- a/Toolkit/SparqlGUI/packages.config
+++ b/Toolkit/SparqlGUI/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="dotNetRDF" version="2.5.0" targetFramework="net40" />
-  <package id="dotNetRDF.Query.FullText" version="2.5.0" targetFramework="net40" />
-  <package id="HtmlAgilityPack" version="1.11.23" targetFramework="net40" />
+  <package id="dotNetRDF" version="2.6.0" targetFramework="net40" />
+  <package id="dotNetRDF.Query.FullText" version="2.6.0" targetFramework="net40" />
+  <package id="HtmlAgilityPack" version="1.11.24" targetFramework="net40" />
   <package id="Lucene.Net" version="3.0.3" targetFramework="net40" />
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net40" />
   <package id="SharpZipLib" version="0.86.0" targetFramework="net40" />

--- a/Toolkit/rdfConvert/RdfConvert.cs
+++ b/Toolkit/rdfConvert/RdfConvert.cs
@@ -296,7 +296,7 @@ namespace VDS.RDF.Utilities.Convert
                     {
                         try
                         {
-                            foreach (String mimeType in MimeTypesHelper.GetMimeTypes(format))
+                            foreach (var mimeType in MimeTypesHelper.GetDefinitionsByFileExtension(format).SelectMany(d=>d.MimeTypes).Distinct())
                             {
                                 this._outFormats.Add(mimeType);
                             }
@@ -394,7 +394,7 @@ namespace VDS.RDF.Utilities.Convert
                 if (this._inputs.Count == 1 && !this._outputFilename.Equals(String.Empty))
                 {
                     //If only 1 input and an output filename can detect the output format from that filename
-                    this._outFormats.AddRange(MimeTypesHelper.GetMimeTypes(MimeTypesHelper.GetTrueFileExtension(this._outputFilename)));
+                    this._outFormats.AddRange(MimeTypesHelper.GetDefinitionsByFileExtension(MimeTypesHelper.GetTrueFileExtension(this._outputFilename)).SelectMany(d=>d.MimeTypes));
                 }
                 else
                 {

--- a/Toolkit/rdfConvert/packages.config
+++ b/Toolkit/rdfConvert/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="dotNetRDF" version="2.5.0" targetFramework="net40" />
-  <package id="HtmlAgilityPack" version="1.11.23" targetFramework="net40" />
+  <package id="dotNetRDF" version="2.6.0" targetFramework="net40" />
+  <package id="HtmlAgilityPack" version="1.11.24" targetFramework="net40" />
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net40" />
   <package id="VDS.Common" version="1.10.0" targetFramework="net40" />
 </packages>

--- a/Toolkit/rdfConvert/rdfConvert.csproj
+++ b/Toolkit/rdfConvert/rdfConvert.csproj
@@ -58,11 +58,11 @@
     </CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="dotNetRDF, Version=2.5.0.0, Culture=neutral, PublicKeyToken=6055ffe4c97cc780, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\dotNetRDF.2.5.0\lib\net40\dotNetRDF.dll</HintPath>
+    <Reference Include="dotNetRDF, Version=2.6.0.0, Culture=neutral, PublicKeyToken=6055ffe4c97cc780, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\dotNetRDF.2.6.0\lib\net40\dotNetRDF.dll</HintPath>
     </Reference>
-    <Reference Include="HtmlAgilityPack, Version=1.11.23.0, Culture=neutral, PublicKeyToken=bd319b19eaf3b43a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\HtmlAgilityPack.1.11.23\lib\Net40\HtmlAgilityPack.dll</HintPath>
+    <Reference Include="HtmlAgilityPack, Version=1.11.24.0, Culture=neutral, PublicKeyToken=bd319b19eaf3b43a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\HtmlAgilityPack.1.11.24\lib\Net40\HtmlAgilityPack.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">

--- a/Toolkit/rdfDBStudio/app.config
+++ b/Toolkit/rdfDBStudio/app.config
@@ -17,7 +17,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="dotNetRDF" publicKeyToken="6055ffe4c97cc780" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-0.0.0.0" newVersion="0.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.5.0.0" newVersion="2.5.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/Toolkit/rdfDBStudio/packages.config
+++ b/Toolkit/rdfDBStudio/packages.config
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="AvalonEdit" version="4.4.2.9744" targetFramework="net40" />
-  <package id="dotNetRDF" version="2.5.0" targetFramework="net40" />
-  <package id="dotNetRDF.Data.Virtuoso" version="2.5.0" targetFramework="net40" />
-  <package id="dotNetRDF.Query.FullText" version="2.5.0" targetFramework="net40" />
-  <package id="HtmlAgilityPack" version="1.11.23" targetFramework="net40" />
+  <package id="dotNetRDF" version="2.6.0" targetFramework="net40" />
+  <package id="dotNetRDF.Data.Virtuoso" version="2.6.0" targetFramework="net40" />
+  <package id="dotNetRDF.Query.FullText" version="2.6.0" targetFramework="net40" />
+  <package id="HtmlAgilityPack" version="1.11.24" targetFramework="net40" />
   <package id="Lucene.Net" version="3.0.3" targetFramework="net40" />
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net40" />
   <package id="OpenLink.Data.Virtuoso" version="7.20.3214.1" targetFramework="net40" />

--- a/Toolkit/rdfDBStudio/rdfDBStudio.csproj
+++ b/Toolkit/rdfDBStudio/rdfDBStudio.csproj
@@ -41,17 +41,17 @@
     <CodeAnalysisRuleSet />
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="dotNetRDF, Version=2.5.0.0, Culture=neutral, PublicKeyToken=6055ffe4c97cc780, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\dotNetRDF.2.5.0\lib\net40\dotNetRDF.dll</HintPath>
+    <Reference Include="dotNetRDF, Version=2.6.0.0, Culture=neutral, PublicKeyToken=6055ffe4c97cc780, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\dotNetRDF.2.6.0\lib\net40\dotNetRDF.dll</HintPath>
     </Reference>
-    <Reference Include="dotNetRDF.Data.Virtuoso, Version=2.5.0.0, Culture=neutral, PublicKeyToken=6055ffe4c97cc780, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\dotNetRDF.Data.Virtuoso.2.5.0\lib\net40\dotNetRDF.Data.Virtuoso.dll</HintPath>
+    <Reference Include="dotNetRDF.Data.Virtuoso, Version=2.6.0.0, Culture=neutral, PublicKeyToken=6055ffe4c97cc780, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\dotNetRDF.Data.Virtuoso.2.6.0\lib\net40\dotNetRDF.Data.Virtuoso.dll</HintPath>
     </Reference>
-    <Reference Include="dotNetRDF.Query.FullText, Version=2.5.0.0, Culture=neutral, PublicKeyToken=6055ffe4c97cc780, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\dotNetRDF.Query.FullText.2.5.0\lib\net40\dotNetRDF.Query.FullText.dll</HintPath>
+    <Reference Include="dotNetRDF.Query.FullText, Version=2.6.0.0, Culture=neutral, PublicKeyToken=6055ffe4c97cc780, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\dotNetRDF.Query.FullText.2.6.0\lib\net40\dotNetRDF.Query.FullText.dll</HintPath>
     </Reference>
-    <Reference Include="HtmlAgilityPack, Version=1.11.23.0, Culture=neutral, PublicKeyToken=bd319b19eaf3b43a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\HtmlAgilityPack.1.11.23\lib\Net40\HtmlAgilityPack.dll</HintPath>
+    <Reference Include="HtmlAgilityPack, Version=1.11.24.0, Culture=neutral, PublicKeyToken=bd319b19eaf3b43a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\HtmlAgilityPack.1.11.24\lib\Net40\HtmlAgilityPack.dll</HintPath>
     </Reference>
     <Reference Include="ICSharpCode.AvalonEdit, Version=4.4.2.9744, Culture=neutral, PublicKeyToken=9cc39be672370310, processorArchitecture=MSIL">
       <HintPath>..\..\packages\AvalonEdit.4.4.2.9744\lib\Net40\ICSharpCode.AvalonEdit.dll</HintPath>

--- a/Toolkit/rdfEditor.Wpf/FileAssociations.xaml.cs
+++ b/Toolkit/rdfEditor.Wpf/FileAssociations.xaml.cs
@@ -197,7 +197,7 @@ namespace VDS.RDF.Utilities.Editor.Wpf
                     info.Create();
                     try
                     {
-                        info.ContentType = MimeTypesHelper.GetMimeType(info.Extension);
+                        info.ContentType = MimeTypesHelper.GetDefinitionsByFileExtension(info.Extension).Select(m=>m.CanonicalMimeType).FirstOrDefault();
                     }
                     catch
                     {
@@ -215,7 +215,7 @@ namespace VDS.RDF.Utilities.Editor.Wpf
                 {
                     try
                     {
-                        String mimeType = MimeTypesHelper.GetMimeType(info.Extension);
+                        var mimeType = MimeTypesHelper.GetDefinitionsByFileExtension(info.Extension).Select(x=>x.CanonicalMimeType).FirstOrDefault();
                         info.ContentType = mimeType;
                     } 
                     catch

--- a/Toolkit/rdfEditor.Wpf/packages.config
+++ b/Toolkit/rdfEditor.Wpf/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="AvalonEdit" version="4.4.2.9744" targetFramework="net40" />
-  <package id="dotNetRDF" version="2.5.0" targetFramework="net40" />
+  <package id="dotNetRDF" version="2.6.0" targetFramework="net40" />
   <package id="FileAssociation" version="1.0.0.0" targetFramework="net40" />
-  <package id="HtmlAgilityPack" version="1.11.23" targetFramework="net40" />
+  <package id="HtmlAgilityPack" version="1.11.24" targetFramework="net40" />
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net40" />
   <package id="VDS.Common" version="1.10.0" targetFramework="net40" />
 </packages>

--- a/Toolkit/rdfEditor.Wpf/rdfEditor.Wpf.csproj
+++ b/Toolkit/rdfEditor.Wpf/rdfEditor.Wpf.csproj
@@ -60,15 +60,15 @@
     </CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="dotNetRDF, Version=2.5.0.0, Culture=neutral, PublicKeyToken=6055ffe4c97cc780, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\dotNetRDF.2.5.0\lib\net40\dotNetRDF.dll</HintPath>
+    <Reference Include="dotNetRDF, Version=2.6.0.0, Culture=neutral, PublicKeyToken=6055ffe4c97cc780, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\dotNetRDF.2.6.0\lib\net40\dotNetRDF.dll</HintPath>
     </Reference>
     <Reference Include="FileAssociation, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\FileAssociation.1.0.0.0\lib\net35\FileAssociation.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="HtmlAgilityPack, Version=1.11.23.0, Culture=neutral, PublicKeyToken=bd319b19eaf3b43a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\HtmlAgilityPack.1.11.23\lib\Net40\HtmlAgilityPack.dll</HintPath>
+    <Reference Include="HtmlAgilityPack, Version=1.11.24.0, Culture=neutral, PublicKeyToken=bd319b19eaf3b43a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\HtmlAgilityPack.1.11.24\lib\Net40\HtmlAgilityPack.dll</HintPath>
     </Reference>
     <Reference Include="ICSharpCode.AvalonEdit, Version=4.4.2.9744, Culture=neutral, PublicKeyToken=9cc39be672370310, processorArchitecture=MSIL">
       <HintPath>..\..\packages\AvalonEdit.4.4.2.9744\lib\Net40\ICSharpCode.AvalonEdit.dll</HintPath>

--- a/Toolkit/rdfOptStats/packages.config
+++ b/Toolkit/rdfOptStats/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="dotNetRDF" version="2.5.0" targetFramework="net40" />
-  <package id="HtmlAgilityPack" version="1.11.23" targetFramework="net40" />
+  <package id="dotNetRDF" version="2.6.0" targetFramework="net40" />
+  <package id="HtmlAgilityPack" version="1.11.24" targetFramework="net40" />
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net40" />
   <package id="VDS.Common" version="1.10.0" targetFramework="net40" />
 </packages>

--- a/Toolkit/rdfOptStats/rdfOptStats.csproj
+++ b/Toolkit/rdfOptStats/rdfOptStats.csproj
@@ -57,11 +57,11 @@
     </CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="dotNetRDF, Version=2.5.0.0, Culture=neutral, PublicKeyToken=6055ffe4c97cc780, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\dotNetRDF.2.5.0\lib\net40\dotNetRDF.dll</HintPath>
+    <Reference Include="dotNetRDF, Version=2.6.0.0, Culture=neutral, PublicKeyToken=6055ffe4c97cc780, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\dotNetRDF.2.6.0\lib\net40\dotNetRDF.dll</HintPath>
     </Reference>
-    <Reference Include="HtmlAgilityPack, Version=1.11.23.0, Culture=neutral, PublicKeyToken=bd319b19eaf3b43a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\HtmlAgilityPack.1.11.23\lib\Net40\HtmlAgilityPack.dll</HintPath>
+    <Reference Include="HtmlAgilityPack, Version=1.11.24.0, Culture=neutral, PublicKeyToken=bd319b19eaf3b43a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\HtmlAgilityPack.1.11.24\lib\Net40\HtmlAgilityPack.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">

--- a/Toolkit/rdfQuery/RdfQuery.cs
+++ b/Toolkit/rdfQuery/RdfQuery.cs
@@ -98,12 +98,13 @@ namespace VDS.RDF.Utilities.Query
                         case RdfQueryMode.Local:
                             if (this._explain)
                             {
-                                ExplainQueryProcessor processor = new ExplainQueryProcessor(this._store, this._level);
+                                var processor = new ExplainQueryProcessor(this._store, this._level);
                                 results = processor.ProcessQuery(q);
                             }
                             else
                             {
-                                results = this._store.ExecuteQuery(q);
+                                var processor = new LeviathanQueryProcessor(_store);
+                                results = processor.ProcessQuery(q);
                             }
                             break;
                         case RdfQueryMode.Remote:
@@ -318,8 +319,8 @@ namespace VDS.RDF.Utilities.Query
                         else
                         {
                             //File Extension
-                            this._graphWriter = MimeTypesHelper.GetWriter(MimeTypesHelper.GetMimeType(format));
-                            this._resultsWriter = MimeTypesHelper.GetSparqlWriter(MimeTypesHelper.GetMimeType(format));
+                            this._graphWriter = MimeTypesHelper.GetWriterByFileExtension(format);
+                            this._resultsWriter = MimeTypesHelper.GetSparqlWriterByFileExtension(format);
                         }
                     }
                     catch (RdfException)

--- a/Toolkit/rdfQuery/RoqetQuery.cs
+++ b/Toolkit/rdfQuery/RoqetQuery.cs
@@ -179,7 +179,9 @@ namespace VDS.RDF.Utilities.Query
             }
             try
             {
-                Object results = this._store.ExecuteQuery(q);
+                //Object results = this._store.ExecuteQuery(q);
+                var processor = new LeviathanQueryProcessor(_store);
+                var results = processor.ProcessQuery(q);
                 if (results is SparqlResultSet)
                 {
                     this._resultsWriter.Save((SparqlResultSet)results, Console.Out);

--- a/Toolkit/rdfQuery/packages.config
+++ b/Toolkit/rdfQuery/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="dotNetRDF" version="2.5.0" targetFramework="net40" />
-  <package id="HtmlAgilityPack" version="1.11.23" targetFramework="net40" />
+  <package id="dotNetRDF" version="2.6.0" targetFramework="net40" />
+  <package id="HtmlAgilityPack" version="1.11.24" targetFramework="net40" />
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net40" />
   <package id="VDS.Common" version="1.10.0" targetFramework="net40" />
 </packages>

--- a/Toolkit/rdfQuery/rdfQuery.csproj
+++ b/Toolkit/rdfQuery/rdfQuery.csproj
@@ -58,11 +58,11 @@
     </CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="dotNetRDF, Version=2.5.0.0, Culture=neutral, PublicKeyToken=6055ffe4c97cc780, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\dotNetRDF.2.5.0\lib\net40\dotNetRDF.dll</HintPath>
+    <Reference Include="dotNetRDF, Version=2.6.0.0, Culture=neutral, PublicKeyToken=6055ffe4c97cc780, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\dotNetRDF.2.6.0\lib\net40\dotNetRDF.dll</HintPath>
     </Reference>
-    <Reference Include="HtmlAgilityPack, Version=1.11.23.0, Culture=neutral, PublicKeyToken=bd319b19eaf3b43a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\HtmlAgilityPack.1.11.23\lib\Net40\HtmlAgilityPack.dll</HintPath>
+    <Reference Include="HtmlAgilityPack, Version=1.11.24.0, Culture=neutral, PublicKeyToken=bd319b19eaf3b43a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\HtmlAgilityPack.1.11.24\lib\Net40\HtmlAgilityPack.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">

--- a/Toolkit/rdfServer/packages.config
+++ b/Toolkit/rdfServer/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="dotNetRDF" version="2.5.0" targetFramework="net40" />
-  <package id="dotNetRDF.Web" version="2.5.0" targetFramework="net40" />
-  <package id="HtmlAgilityPack" version="1.11.23" targetFramework="net40" />
+  <package id="dotNetRDF" version="2.6.0" targetFramework="net40" />
+  <package id="dotNetRDF.Web" version="2.6.0" targetFramework="net40" />
+  <package id="HtmlAgilityPack" version="1.11.24" targetFramework="net40" />
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net40" />
   <package id="VDS.Common" version="1.10.0" targetFramework="net40" />
   <package id="VDS.Web.Server" version="1.2.0" targetFramework="net40" />

--- a/Toolkit/rdfServer/rdfServer.csproj
+++ b/Toolkit/rdfServer/rdfServer.csproj
@@ -57,14 +57,14 @@
     </CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="dotNetRDF, Version=2.5.0.0, Culture=neutral, PublicKeyToken=6055ffe4c97cc780, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\dotNetRDF.2.5.0\lib\net40\dotNetRDF.dll</HintPath>
+    <Reference Include="dotNetRDF, Version=2.6.0.0, Culture=neutral, PublicKeyToken=6055ffe4c97cc780, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\dotNetRDF.2.6.0\lib\net40\dotNetRDF.dll</HintPath>
     </Reference>
-    <Reference Include="dotNetRDF.Web, Version=2.5.0.0, Culture=neutral, PublicKeyToken=6055ffe4c97cc780, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\dotNetRDF.Web.2.5.0\lib\net40\dotNetRDF.Web.dll</HintPath>
+    <Reference Include="dotNetRDF.Web, Version=2.6.0.0, Culture=neutral, PublicKeyToken=6055ffe4c97cc780, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\dotNetRDF.Web.2.6.0\lib\net40\dotNetRDF.Web.dll</HintPath>
     </Reference>
-    <Reference Include="HtmlAgilityPack, Version=1.11.23.0, Culture=neutral, PublicKeyToken=bd319b19eaf3b43a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\HtmlAgilityPack.1.11.23\lib\Net40\HtmlAgilityPack.dll</HintPath>
+    <Reference Include="HtmlAgilityPack, Version=1.11.24.0, Culture=neutral, PublicKeyToken=bd319b19eaf3b43a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\HtmlAgilityPack.1.11.24\lib\Net40\HtmlAgilityPack.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">

--- a/Toolkit/soh/packages.config
+++ b/Toolkit/soh/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="dotNetRDF" version="2.5.0" targetFramework="net40" />
-  <package id="HtmlAgilityPack" version="1.11.23" targetFramework="net40" />
+  <package id="dotNetRDF" version="2.6.0" targetFramework="net40" />
+  <package id="HtmlAgilityPack" version="1.11.24" targetFramework="net40" />
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net40" />
   <package id="VDS.Common" version="1.10.0" targetFramework="net40" />
 </packages>

--- a/Toolkit/soh/soh.csproj
+++ b/Toolkit/soh/soh.csproj
@@ -57,11 +57,11 @@
     </CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="dotNetRDF, Version=2.5.0.0, Culture=neutral, PublicKeyToken=6055ffe4c97cc780, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\dotNetRDF.2.5.0\lib\net40\dotNetRDF.dll</HintPath>
+    <Reference Include="dotNetRDF, Version=2.6.0.0, Culture=neutral, PublicKeyToken=6055ffe4c97cc780, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\dotNetRDF.2.6.0\lib\net40\dotNetRDF.dll</HintPath>
     </Reference>
-    <Reference Include="HtmlAgilityPack, Version=1.11.23.0, Culture=neutral, PublicKeyToken=bd319b19eaf3b43a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\HtmlAgilityPack.1.11.23\lib\Net40\HtmlAgilityPack.dll</HintPath>
+    <Reference Include="HtmlAgilityPack, Version=1.11.24.0, Culture=neutral, PublicKeyToken=bd319b19eaf3b43a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\HtmlAgilityPack.1.11.24\lib\Net40\HtmlAgilityPack.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">

--- a/Toolkit/storemanager/StoreManager.csproj
+++ b/Toolkit/storemanager/StoreManager.csproj
@@ -59,17 +59,17 @@
     </CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="dotNetRDF, Version=2.5.0.0, Culture=neutral, PublicKeyToken=6055ffe4c97cc780, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\dotNetRDF.2.5.0\lib\net40\dotNetRDF.dll</HintPath>
+    <Reference Include="dotNetRDF, Version=2.6.0.0, Culture=neutral, PublicKeyToken=6055ffe4c97cc780, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\dotNetRDF.2.6.0\lib\net40\dotNetRDF.dll</HintPath>
     </Reference>
-    <Reference Include="dotNetRDF.Data.Virtuoso, Version=2.5.0.0, Culture=neutral, PublicKeyToken=6055ffe4c97cc780, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\dotNetRDF.Data.Virtuoso.2.5.0\lib\net40\dotNetRDF.Data.Virtuoso.dll</HintPath>
+    <Reference Include="dotNetRDF.Data.Virtuoso, Version=2.6.0.0, Culture=neutral, PublicKeyToken=6055ffe4c97cc780, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\dotNetRDF.Data.Virtuoso.2.6.0\lib\net40\dotNetRDF.Data.Virtuoso.dll</HintPath>
     </Reference>
-    <Reference Include="dotNetRDF.Query.FullText, Version=2.5.0.0, Culture=neutral, PublicKeyToken=6055ffe4c97cc780, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\dotNetRDF.Query.FullText.2.5.0\lib\net40\dotNetRDF.Query.FullText.dll</HintPath>
+    <Reference Include="dotNetRDF.Query.FullText, Version=2.6.0.0, Culture=neutral, PublicKeyToken=6055ffe4c97cc780, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\dotNetRDF.Query.FullText.2.6.0\lib\net40\dotNetRDF.Query.FullText.dll</HintPath>
     </Reference>
-    <Reference Include="HtmlAgilityPack, Version=1.11.23.0, Culture=neutral, PublicKeyToken=bd319b19eaf3b43a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\HtmlAgilityPack.1.11.23\lib\Net40\HtmlAgilityPack.dll</HintPath>
+    <Reference Include="HtmlAgilityPack, Version=1.11.24.0, Culture=neutral, PublicKeyToken=bd319b19eaf3b43a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\HtmlAgilityPack.1.11.24\lib\Net40\HtmlAgilityPack.dll</HintPath>
     </Reference>
     <Reference Include="ICSharpCode.SharpZipLib, Version=0.86.0.518, Culture=neutral, PublicKeyToken=1b03e6acf1164f73, processorArchitecture=MSIL">
       <HintPath>..\..\packages\SharpZipLib.0.86.0\lib\20\ICSharpCode.SharpZipLib.dll</HintPath>

--- a/Toolkit/storemanager/app.config
+++ b/Toolkit/storemanager/app.config
@@ -62,7 +62,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="dotNetRDF" publicKeyToken="6055ffe4c97cc780" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-0.0.0.0" newVersion="0.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.5.0.0" newVersion="2.5.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/Toolkit/storemanager/packages.config
+++ b/Toolkit/storemanager/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="dotNetRDF" version="2.5.0" targetFramework="net40" />
-  <package id="dotNetRDF.Data.Virtuoso" version="2.5.0" targetFramework="net40" />
-  <package id="dotNetRDF.Query.FullText" version="2.5.0" targetFramework="net40" />
-  <package id="HtmlAgilityPack" version="1.11.23" targetFramework="net40" />
+  <package id="dotNetRDF" version="2.6.0" targetFramework="net40" />
+  <package id="dotNetRDF.Data.Virtuoso" version="2.6.0" targetFramework="net40" />
+  <package id="dotNetRDF.Query.FullText" version="2.6.0" targetFramework="net40" />
+  <package id="HtmlAgilityPack" version="1.11.24" targetFramework="net40" />
   <package id="Lucene.Net" version="3.0.3" targetFramework="net40" />
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net40" />
   <package id="OpenLink.Data.Virtuoso" version="7.20.3214.1" targetFramework="net40" />

--- a/ToolkitInstaller/ToolkitInstaller.wixproj
+++ b/ToolkitInstaller/ToolkitInstaller.wixproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
-    <ProductVersion>3.10</ProductVersion>
+    <ProductVersion>3.11</ProductVersion>
     <ProjectGuid>5bf10fa7-95b7-42b4-8f17-65ae02aa65fe</ProjectGuid>
     <SchemaVersion>2.0</SchemaVersion>
     <OutputName>dotNetRdf-Toolkit</OutputName>


### PR DESCRIPTION
This PR updates the library dependencies to use the 2.6.0 release of dotNetRDF. It also addresses a small number of uses of APIs that have been obsoleted in the dotNetRDF libraries.