### PR TITLE
Update bug report links

### DIFF
--- a/Toolkit/rdfEditor.Wpf/About.xaml
+++ b/Toolkit/rdfEditor.Wpf/About.xaml
@@ -30,7 +30,7 @@
         <Label Grid.Column="1" Grid.Row="3" Name="lblRdfVersion">0.0.0.0</Label>
         
         <TextBlock Grid.Row="4" Grid.ColumnSpan="2" TextWrapping="Wrap" Padding="4">rdfEditor is based upon the free and open source AvalonEdit component which was developed by Daniel Grunwald as part of the SharpDevelop project</TextBlock>
-        
-        <TextBlock Grid.Row="5" Grid.ColumnSpan="2" TextWrapping="Wrap" Padding="4" Margin="0,6,0,0">rdfEditor is currently Alpha so please be aware this software may be buggy - please report all bugs to <Hyperlink>dotnetrdf-bugreports@lists.sourceforge.net</Hyperlink></TextBlock>
+
+        <TextBlock Grid.Row="5" Grid.ColumnSpan="2" TextWrapping="Wrap" Padding="4" Margin="0,6,0,0">rdfEditor is currently Alpha so please be aware this software may be buggy - please report all bugs to <Hyperlink>https://github.com/dotnetrdf/dotNetRDF.Toolkit/issues</Hyperlink></TextBlock>
     </Grid>
 </Window>

--- a/Toolkit/rdfQuery/RoqetQuery.cs
+++ b/Toolkit/rdfQuery/RoqetQuery.cs
@@ -316,7 +316,7 @@ namespace VDS.RDF.Utilities.Query
                 else if (arg.Equals("-v") || arg.Equals("--version"))
                 {
                     Console.WriteLine("dotNetRDF Version " + Assembly.GetAssembly(typeof(Triple)).GetName().Version.ToString());
-                    Console.WriteLine("Copyright Rob Vesse 2009-10");
+                    Console.WriteLine("rdfQuery Version: " + Assembly.GetExecutingAssembly().GetName().Version.ToString());
                     Console.WriteLine("http://www.dotnetrdf.org");
                     return false;
                 }

--- a/Toolkit/storemanager/Forms/AboutForm.resx
+++ b/Toolkit/storemanager/Forms/AboutForm.resx
@@ -120,7 +120,7 @@
   <data name="lblInfo.Text" xml:space="preserve">
     <value>Store Manager is part of the dotNetRDF Toolkit for Windows.  It provides a GUI for working with a variety of different RDF stores that are supported by dotNetRDF.  It also has the ability for users to add their own connection types for arbitrary storage backends.
 
-While every effort is made to keep this software as bug free as possible ocassionally we make mistakes or miss things, please report any issues to the mailing list at dotnetrdf-bugs@lists.sourceforge.net</value>
+While every effort is made to keep this software as bug free as possible ocassionally we make mistakes or miss things, please report any issues on our bug tracker at https://github.com/dotnetrdf/dotNetRDF.Toolkit/issues</value>
   </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">


### PR DESCRIPTION
Fixes a couple of the GUI dialogs to replace references to the old mailing list with a link to the GitHub issues page.
Also updated rdfQuery to remove old copyright notice and instead display the tool version number.